### PR TITLE
Give `setFrames` more info

### DIFF
--- a/src/graphics/Screen.h
+++ b/src/graphics/Screen.h
@@ -126,6 +126,10 @@ class Screen : public concurrency::OSThread
         CallbackObserver<Screen, const meshtastic::Status *>(this, &Screen::handleStatusUpdate);
     CallbackObserver<Screen, const meshtastic_MeshPacket *> textMessageObserver =
         CallbackObserver<Screen, const meshtastic_MeshPacket *>(this, &Screen::handleTextMessage);
+    CallbackObserver<Screen, const meshtastic_MeshPacket *> waypointObserver =
+        CallbackObserver<Screen, const meshtastic_MeshPacket *>(this, &Screen::handleWaypoint);
+    CallbackObserver<Screen, const meshtastic_AdminMessage *> adminMessageObserver =
+        CallbackObserver<Screen, const meshtastic_AdminMessage *>(this, &Screen::handleAdminMessage);
     CallbackObserver<Screen, const UIFrameEvent *> uiFrameEventObserver =
         CallbackObserver<Screen, const UIFrameEvent *>(this, &Screen::handleUIFrameEvent);
     CallbackObserver<Screen, const InputEvent *> inputObserver =
@@ -336,6 +340,8 @@ class Screen : public concurrency::OSThread
     int handleTextMessage(const meshtastic_MeshPacket *arg);
     int handleUIFrameEvent(const UIFrameEvent *arg);
     int handleInputEvent(const InputEvent *arg);
+    int handleWaypoint(const meshtastic_MeshPacket *arg);
+    int handleAdminMessage(const meshtastic_AdminMessage *arg);
 
     /// Used to force (super slow) eink displays to draw critical frames
     void forceDisplay(bool forceUiUpdate = false);
@@ -389,8 +395,17 @@ class Screen : public concurrency::OSThread
     void handleStartFirmwareUpdateScreen();
     void handleShutdownScreen();
     void handleRebootScreen();
+
+    // Which frame we want to be displayed, after we redraw with setFrames()
+    enum targetFrame : uint8_t {
+        TARGETFRAME_DEFAULT,  // No specific frame
+        TARGETFRAME_PRESERVE, // Return to the previous frame
+        TARGETFRAME_TEXTMESSAGE,
+        TARGETFRAME_WAYPOINT,
+    };
+
     /// Rebuilds our list of frames (screens) to default ones.
-    void setFrames(bool holdPosition = false);
+    void setFrames(targetFrame target = TARGETFRAME_DEFAULT);
 
     /// Try to start drawing ASAP
     void setFastFramerate();

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -200,6 +200,7 @@ bool AdminModule::handleReceivedProtobuf(const meshtastic_MeshPacket &mp, meshta
     case meshtastic_AdminMessage_remove_by_nodenum_tag: {
         LOG_INFO("Client is receiving a remove_nodenum command.\n");
         nodeDB->removeNodeByNum(r->remove_by_nodenum);
+        this->notifyObservers(r);
         break;
     }
     case meshtastic_AdminMessage_set_favorite_node_tag: {

--- a/src/modules/AdminModule.h
+++ b/src/modules/AdminModule.h
@@ -7,7 +7,7 @@
 /**
  * Admin module for admin messages
  */
-class AdminModule : public ProtobufModule<meshtastic_AdminMessage>
+class AdminModule : public ProtobufModule<meshtastic_AdminMessage>, public Observable<const meshtastic_AdminMessage *>
 {
   public:
     /** Constructor

--- a/src/modules/CannedMessageModule.h
+++ b/src/modules/CannedMessageModule.h
@@ -82,8 +82,14 @@ class CannedMessageModule : public SinglePortModule, public Observable<const UIF
 
         switch (p->decoded.portnum) {
         case meshtastic_PortNum_TEXT_MESSAGE_APP:
-        case meshtastic_PortNum_ROUTING_APP:
             return true;
+        case meshtastic_PortNum_ROUTING_APP:
+            // We don't want routing messages if we're not using the canned messages module
+            // Causes the screen to redraw at strange times, returning to frame 0
+            if (this->runState == CANNED_MESSAGE_RUN_STATE_DISABLED)
+                return false;
+            else
+                return true;
         default:
             return false;
         }


### PR DESCRIPTION
(For consideration: possible way to handle https://github.com/meshtastic/firmware/pull/4043)

I've just thrown this one together right now on my way to bed. Hopefully it exposes some more information which you can use in `setFrames` to decide which frame to change to. It's not implemented in `setFrames` yet, so it'd need a bit of a rewrite there. The new enum value `TARGETFRAME_PRESERVE` is used to indicate that we should try to return to the same frame, but the other enum values passed make specific requests about which frame to show. 

It might be convenient too to use that `TargetFrame` enum type to store some info inside `screenFrames`, instead of the `oldNumFrames` stuff. Not sure about that though!

Just submitting this as a draft, because I'm not 100% sure about it, but if you do want to try work with it, and get good results, feel free to merge it anyway.

I don't *think* anyone will object to observing the AdminModule this way, but you never know; will have to ask that tomorrow too.